### PR TITLE
Improve event logger: JSON output, remove glow, add filter & copy

### DIFF
--- a/dynamic-form-loader/Components/Atoms/LogScreen/LogScreen.js
+++ b/dynamic-form-loader/Components/Atoms/LogScreen/LogScreen.js
@@ -15,14 +15,12 @@ export class LogScreen extends HTMLElement {
           border-radius: 8px;
           margin: 10px 0;
           font-family: var(--font-family-monospace), monospace;
-          font-weight: bold;
           overflow: hidden;
           overflow-y: auto;
           height: 400px;
-          text-shadow: 0 0 6px #737dff;
           scrollbar-width: thin;
           scrollbar-color: #152B49FF #1d4172;
-          box-shadow: inset 0 0 30px #131d27, 0 0 18px -3px #3544fa33;
+          box-shadow: inset 0 0 30px #131d27;
           border-top: 3px solid var(--color-cream);
           border-left: 3px solid var(--color-cream);
           border-bottom: 3px solid var(--color-white);

--- a/dynamic-form-loader/datalayer-logger.js
+++ b/dynamic-form-loader/datalayer-logger.js
@@ -1,3 +1,6 @@
+const COPY_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+const CHECK_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
 customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElement {
   constructor() {
     super();
@@ -16,7 +19,6 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
             overflow: hidden;
             border-radius: 3px;
             border: 1px solid white;
-            box-shadow: 0 0 2px #737dff, inset 0 0 2px #737dff;
         }
         .messageItem {
             padding: 5px;
@@ -26,15 +28,60 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
             overflow: hidden;
             border-radius: 3px;
             border: 1px solid white;
-            box-shadow: 0 0 2px #737dff, inset 0 0 2px #737dff;
+        }
+        .json {
+            font-family: "Inconsolata", monospace;
+            font-size: 12px;
+            font-weight: normal;
+            line-height: 1.4;
+            white-space: pre-wrap;
+            word-break: break-word;
+            margin: 5px 0 0;
+            color: #d7e3f4;
+        }
+        .copyBtn {
+            float: right;
+            background: transparent;
+            border: none;
+            color: #c792ff;
+            cursor: pointer;
+            padding: 0 4px;
+            display: inline-flex;
+            align-items: center;
+            border-radius: 3px;
+            line-height: 1;
+        }
+        .copyBtn:hover {
+            color: white;
+            background: rgba(255, 255, 255, 0.12);
+        }
+        .copyBtn.copied {
+            color: #7CFC9A;
+        }
+        .copyBtn svg {
+            display: block;
         }
         .timestamp {
             font-size: 14px;
             color: #c792ff;
-            text-shadow: 0 0 2px blueviolet;
             text-align: right;
             font-weight: normal;
             margin-top: 5px;
+        }
+        .searchInput {
+            width: 100%;
+            box-sizing: border-box;
+            margin-bottom: 10px;
+            padding: 6px 10px;
+            font-size: 12px;
+            font-family: inherit;
+            color: white;
+            background: rgb(28, 39, 58);
+            border: 1px solid white;
+            border-radius: 16px;
+        }
+        .searchInput::placeholder {
+            color: rgba(255, 255, 255, 0.6);
         }
         summary {
             cursor: pointer;
@@ -86,6 +133,7 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
               <zui-toggle id="dataLayerToggle" checked><div slot="label">Datalayer</div></zui-toggle>
               <zui-toggle id="internalToggle" checked><div slot="label">Chameleon internal</div></zui-toggle>
             </div>
+            <input type="search" id="eventSearch" class="searchInput" placeholder="Filter events by name…" autocomplete="off" spellcheck="false">
             <zui-log-screen class="logContainer"></zui-log-screen>
             </div>
           </div>
@@ -94,7 +142,8 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
 
     this.config = {
         showDataLayer: true,
-        showInternal: true
+        showInternal: true,
+        searchTerm: ''
     }
   }
 
@@ -111,6 +160,24 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
     this.shadowRoot.getElementById('internalToggle').addEventListener('zui-toggle-change', (e) => {
         this.config.showInternal = e.detail.checked;
         this.filterLogs();
+    });
+    this.shadowRoot.getElementById('eventSearch').addEventListener('input', (e) => {
+        this.config.searchTerm = e.target.value.trim().toLowerCase();
+        this.filterLogs();
+    });
+    this.shadowRoot.querySelector('.logContainer').addEventListener('click', (e) => {
+        const btn = e.target.closest('.copyBtn');
+        if (!btn) return;
+        e.preventDefault(); // don't toggle the <details> when copying
+        const details = btn.closest('details');
+        const jsonEl = details && details.querySelector('.json');
+        navigator.clipboard.writeText(jsonEl ? jsonEl.textContent : '');
+        btn.classList.add('copied');
+        btn.innerHTML = CHECK_ICON;
+        setTimeout(() => {
+            btn.classList.remove('copied');
+            btn.innerHTML = COPY_ICON;
+        }, 1000);
     });
     this.shadowRoot.getElementById('statusLight').setAttribute('status', 'success');
   }
@@ -152,6 +219,7 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
     const logContainer = this.shadowRoot.querySelector('.logContainer');
     const logItem = document.createElement('details');
     logItem.classList.add('logItem', 'dataLayer');
+    logItem.dataset.event = String(data.event ?? '');
     logItem.innerHTML = this.formatMessage(data.event, data, 'dataLayer');
     logContainer.appendChild(logItem);
     this.filterLogs();
@@ -165,6 +233,7 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
       const eventInfoArray = data.split(/:(.+)/);
       const eventType = eventInfoArray[0];
       const parsedData = JSON.parse(eventInfoArray[1]);
+      messageItem.dataset.event = String(eventType ?? '');
       messageItem.innerHTML = this.formatMessage(eventType, parsedData, 'internal');
       logContainer.appendChild(messageItem);
       this.filterLogs();
@@ -174,16 +243,27 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
   }
 
   formatMessage(eventType, data, source) {
-    let html = `<summary>${eventType} <small>${source}</small></summary>`;
-    html += `${this.formatData(data)};`
-    html += `<div class="timestamp">timestamp: ${Date.now()}</div>`;
+    let html = `<summary>${this.escapeHtml(eventType)} <small>${this.escapeHtml(source)}</small><button class="copyBtn" type="button" title="Copy JSON" aria-label="Copy JSON">${COPY_ICON}</button></summary>`;
+    html += this.formatData(data);
+    html += `<div class="timestamp">${this.escapeHtml(new Date().toLocaleTimeString())}</div>`;
     return html;
   }
 
   formatData(data) {
-    return Object.keys(data).map(key => {
-      return `<strong>${key}</strong>: ${typeof data[key] === 'string' || typeof data[key] === 'number' ? data[key] : JSON.stringify(data[key])}`;
-    }).join('<br>');
+    let json;
+    try {
+      json = JSON.stringify(data, null, 2);
+    } catch (e) {
+      json = String(data);
+    }
+    return `<pre class="json">${this.escapeHtml(json)}</pre>`;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   clearLogs() {
@@ -194,16 +274,15 @@ customElements.define('datalayer-logger', class dataLayerLogger extends HTMLElem
   filterLogs() {
     const showDataLayer = this.config.showDataLayer;
     const showInternal = this.config.showInternal;
+    const searchTerm = this.config.searchTerm;
 
-    const logItems = this.shadowRoot.querySelectorAll('.logItem');
-    const messageItems = this.shadowRoot.querySelectorAll('.messageItem');
+    const items = this.shadowRoot.querySelectorAll('.logItem, .messageItem');
 
-    logItems.forEach(item => {
-      item.style.display = showDataLayer ? 'block' : 'none';
-    });
-
-    messageItems.forEach(item => {
-      item.style.display = showInternal ? 'block' : 'none';
+    items.forEach(item => {
+      const sourceVisible = item.classList.contains('dataLayer') ? showDataLayer : showInternal;
+      const eventName = (item.dataset.event || '').toLowerCase();
+      const matchesSearch = !searchTerm || eventName.includes(searchTerm);
+      item.style.display = sourceVisible && matchesSearch ? 'block' : 'none';
     });
   }
 });


### PR DESCRIPTION
## What & why

Improves the dynamic form loader's **Event logger** helper to make events easier to read and work with.

### Changes
- **Readable JSON** — event payloads now render as pretty-printed, indented JSON in the monospace font, replacing the old flat `key: value` list. Long values wrap instead of overflowing. Timestamps show as local time (e.g. `14:32:07`) rather than raw epoch ms.
- **Glow removed** — stripped the blue `text-shadow`/`box-shadow` glow from log entries, the timestamp, and the shared `LogScreen` component (`text-shadow: 0 0 6px #737dff`, the blue outer box glow, and forced `bold`) for legibility.
- **Event-name filter** — a live text-search box (`type="search"`) that shows only events whose name matches what you type. Composes with the existing Datalayer/Internal source toggles via a single visibility rule.
- **Per-entry copy icon** — each event gets a copy button that copies that event's JSON to the clipboard (event-delegated handler, with check-icon feedback).

### Security note
The previous `formatData()` injected event values into `innerHTML` unescaped. This PR escapes all dynamic content (JSON body, event name, source) before insertion, closing that injection path.

## Files
- `dynamic-form-loader/datalayer-logger.js` — JSON rendering, escaping, filter, copy, timestamp.
- `dynamic-form-loader/Components/Atoms/LogScreen/LogScreen.js` — remove text/box glow and forced bold (only consumer is the event logger).

## Verification
- **Browser-verified** (Playwright, served locally): pretty-printed JSON output, HTML escaping (no markup injection), `text-shadow` computed `none`, normal font-weight, copy buttons present, `data-event` tagging correct.
- **Code-inspection only**: live filter visibility and copy-click behavior — the Playwright session was too unstable to drive interactively. Straightforward to confirm in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)